### PR TITLE
Update footer.html

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -1,4 +1,3 @@
 <small>© 2018 Artem Anufrij.</small>
 <br>
-<a href="https://github.com/artemanufrij">Github</a>
-<a href="https://plus.google.com/+ArtemAnufrij">Google+</a>
+<a href="https://github.com/artemanufrij">GitHub</a>


### PR DESCRIPTION
Google has announced plans to [sunset Google+ on April 2nd](https://support.google.com/plus/answer/9195133) the footer link will stop functioning at that point so perhaps it should be removed ahead of that date. 

GitHub also changed its wordmark from `Github` to `GitHub` so updating the GitHub link to reflect that change.